### PR TITLE
Add poetry install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ An example is shown below.
 export BLOCKFROST_PROJECT_ID=<your-blockfrost-key>
 # Alternatively, set up ogmios to point to localhost:1337
 
+# Install all dependencies
+poetry install
 # Activate the poetry shell
 poetry shell
 # Create a key pair


### PR DESCRIPTION
It seems that poetry install is missing. I tried running the arguments in the scripts section and got some import errors. Similar errors have also been reported on discord: https://discord.com/channels/1229675253685555253/1229675877588008980/1236905996509773897